### PR TITLE
Remove main project dependency to build translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 D=${HOME}/.local/share/iaito/translations
+SOURCES=$(wildcard */*.ts)
 
 all:
 	$(MAKE) install
@@ -20,7 +21,7 @@ install: build
 build:
 	rm -rf build
 	mkdir -p build
-	lrelease ../Iaito.pro
+	lrelease $(SOURCES)
 	cp */*.qm build
 
 user-install: build

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-D=${HOME}/.local/share/iaito/translations
+PREFIX:=/usr/local
 SOURCES=$(wildcard */*.ts)
 
 all:
-	$(MAKE) install
+	$(MAKE) build
 	$(MAKE) allzip
 
 allzip:
@@ -14,9 +14,11 @@ allzip:
 
 clean:
 	rm -f all.zip
-	rm -rf build
+	rm -rf all build
+	rm -f */*.qm
 
 install: build
+	install -Dm644 -t $(PREFIX)/share/iaito/translations build/*.qm
 
 build:
 	rm -rf build
@@ -24,8 +26,7 @@ build:
 	lrelease $(SOURCES)
 	cp */*.qm build
 
-user-install: build
-	mkdir -p "$(D)"
-	cp -rf build/* "$(D)/"
+user-install:
+	$(MAKE) install PREFIX=${HOME}/.local
 
 .PHONY: all allzip clean install user-install


### PR DESCRIPTION
This will allow to build and install the translations without depending of being a submodule of the main app.
Also implemented the install to /usr/local and user-install to the user home.

IMPORTANT: the previous behavior of `install` that did only the build has been changed to perform the actual install.